### PR TITLE
Drop 1.19 support, breaks worldpreview

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -17,7 +17,7 @@
     "atum": "*"
   },
   "breaks": {
-    "lazystronghold": "*"
+    "lazystronghold": "*",
     "worldpreview": "*"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -13,10 +13,11 @@
   ],
   "depends": {
     "fabricloader": ">=0.12.2",
-    "minecraft": ">=1.18",
+    "minecraft": "1.18.x",
     "atum": "*"
   },
   "breaks": {
     "lazystronghold": "*"
+    "worldpreview": "*"
   }
 }


### PR DESCRIPTION
repository will probably also need to be renamed